### PR TITLE
Encodingの修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,10 +1,10 @@
 default: &default
-  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
   adapter: mysql2
+  encoding: utf8mb4
   username: root
   password:
   host: localhost
@@ -13,6 +13,7 @@ development:
 test:
   <<: *default
   adapter: mysql2
+  encoding: utf8mb4
   username: root
   password:
   host: localhost
@@ -21,4 +22,5 @@ test:
 production:
   <<: *default
   adapter: postgresql
+  encoding: unicode
   url: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  encoding: utf8mb4
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,16 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_12_31_070403) do
-  create_table "journals", charset: "utf8", force: :cascade do |t|
+  create_table "journals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.date "entry_date", null: false
-    t.text "content", null: false
+    t.text "content", size: :medium, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_journals_on_user_id"
   end
 
-  create_table "mood_options", charset: "utf8", force: :cascade do |t|
+  create_table "mood_options", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "optionable_type", null: false
     t.bigint "optionable_id", null: false
     t.json "colors", null: false
@@ -31,10 +31,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_31_070403) do
     t.index ["optionable_type", "optionable_id"], name: "index_mood_options_on_optionable"
   end
 
-  create_table "tasks", charset: "utf8", force: :cascade do |t|
+  create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.datetime "due_date"
     t.integer "status", default: 0
     t.integer "priority", default: 0
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_31_070403) do
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
-  create_table "users", charset: "utf8", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false


### PR DESCRIPTION
# WHAT
・MySQL が対応する環境開発とテスト環境は、encoding: utf8mb4 
・PostgreSQL が対応する本番環境は、encoding: unicode 

# WHY
・それぞれのデータベースで対応できるencodingが異なるため